### PR TITLE
[Hotfix] Correcao de mensagem campos obrigatórios.

### DIFF
--- a/src/Invoice/AddInvoicePayment.php
+++ b/src/Invoice/AddInvoicePayment.php
@@ -214,7 +214,7 @@ class AddInvoicePayment extends Base
             case is_null($this->getInvoiceid()):
             case is_null($this->getTransid()):
             case is_null($this->getGateway()):
-                throw new Exception('Informe todos os campos obrigatórios [action, invoiceid, transid, gateway].');
+                throw new Exception('Informe todos os campos obrigatórios [invoiceid, transid, gateway].');
                 break;
         }
 

--- a/tests/Invoice/AddInvoicePayment/ValidFieldRequiredTest.php
+++ b/tests/Invoice/AddInvoicePayment/ValidFieldRequiredTest.php
@@ -9,7 +9,7 @@ class ValidFieldRequiredTest extends TestCase
 {
     /**
      * @expectedException        Exception
-     * @expectedExceptionMessage Informe todos os campos obrigatórios [action, invoiceid, transid, gateway].
+     * @expectedExceptionMessage Informe todos os campos obrigatórios [invoiceid, transid, gateway].
      */
     public function testRequiredInvoiceid()
     {
@@ -23,7 +23,7 @@ class ValidFieldRequiredTest extends TestCase
 
     /**
      * @expectedException        Exception
-     * @expectedExceptionMessage Informe todos os campos obrigatórios [action, invoiceid, transid, gateway].
+     * @expectedExceptionMessage Informe todos os campos obrigatórios [invoiceid, transid, gateway].
      */
     public function testRequiredTransid()
     {
@@ -37,7 +37,7 @@ class ValidFieldRequiredTest extends TestCase
 
     /**
      * @expectedException        Exception
-     * @expectedExceptionMessage Informe todos os campos obrigatórios [action, invoiceid, transid, gateway].
+     * @expectedExceptionMessage Informe todos os campos obrigatórios [invoiceid, transid, gateway].
      */
     public function testRequiredGateway()
     {


### PR DESCRIPTION
- ao informar os campos obrigatorios, estava informando que o campos action era obrigatorio, sendo que esse campo nao tem como ser informado
ao instanciar o objeto, pois ele ja e informado no propio contrutor automatico.

Issue #2